### PR TITLE
style: Add github templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+Describe the bug
+================
+
+A clear and concise description of what the bug is.
+
+To Reproduce
+============
+
+Steps to reproduce the behavior:
+
+1. Go on '...'
+2. Do '....'
+3. Then do '....'
+4. See error
+
+Expected behavior
+=================
+
+A clear and concise description of what you expected to happen.
+
+Screenshots
+===========
+
+If applicable, add screenshots to help explain your problem.
+
+Device
+======
+
+- Kind: [one of server/desktop/smartphone]
+- OS: [e.g. Ubuntu 18.04, OS X 10.14, Android 8, iOS 13...]
+- Browser: [if applicable: Firefox 65, Chrome 62, Safari 12...]
+- [And any other you may find useful]
+
+Additional context
+==================
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+Is your feature request related to a problem? Please describe
+==============================================================
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+Describe the solution you'd like
+================================
+
+A clear and concise description of what you want to happen.
+
+Describe alternatives you've considered
+=======================================
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+Additional context
+==================
+
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Description format: type(scope): Short description (72 chars max for line) -->
+<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, merge, perf, refactor, revert, style, tests -->
+
+Abstract
+========
+
+A short description of the issue being addressed.
+
+Motivation
+==========
+
+Clearly explain why this is needed.
+
+Rationale
+=========
+
+Describe why particular design decisions were made.

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,4 +1,5 @@
 type(scope): Short description (72 chars max for line)
+# `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, merge, perf, refactor, revert, style, tests [remove this line when done]
 
 Abstract
 ========


### PR DESCRIPTION
Abstract
========

Add one template for pull requests and two for issues (bug report and feature request)

Motivation
==========

It is better to add a common style among issues (same for pull requests) and providing a template helps the users to answer more questions than they would have without it.

Rationale
=========

The issues templates where created using the github generator and slightly modified.

This PR also updates the `.gitmessage` file to list inside the accepted types
