### PR TITLE
feat(domain): Add first domain context and entities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,13 +201,16 @@ jobs:
           command: |
             ls -la
             mv dist _dist
-            rm -r isshub
+            find ./isshub/ -type f -not -path '*/tests/*' -not -path '*/features/*' -delete
+            find ./isshub/ -type d -empty -delete
+            find ./isshub/ -type d -not -path '*/tests/*' -not -path '*/features/*' -not -name 'tests' -not -name 'features' -exec touch "{}/__init__.py" \;
+            mv isshub isshub_tests
             make full-clean
             python -m venv ~/venv
             source ~/venv/bin/activate
             pip install --upgrade pip
             pip install $(ls -tr _dist/*.whl | tail -n 1)[tests]
-            make tests
+            make tests-nocov
 
   # will test that the python tar.gz package is installable and works
   test_python_package_targz:
@@ -226,13 +229,16 @@ jobs:
             source ~/venv/bin/activate
             pip install --upgrade pip
             mv dist _dist
-            rm -r isshub
+            find ./isshub/ -type f -not -path '*/tests/*' -not -path '*/features/*' -delete
+            find ./isshub/ -type d -empty -delete
+            find ./isshub/ -type d -not -path '*/tests/*' -not -path '*/features/*' -not -name 'tests' -not -name 'features' -exec touch "{}/__init__.py" \;
+            mv isshub isshub_tests
             make full-clean
             python -m venv ~/venv
             source ~/venv/bin/activate
             pip install --upgrade pip
             pip install $(ls -tr _dist/*.tar.gz | tail -n 1)[tests]
-            make tests
+            make tests-nocov
 
 workflows:
   version: 2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.rst

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ dev-upgrade:  ## Upgrade all default+dev dependencies defined in setup.cfg
 
 .PHONY: dist
 dist:  ## Build the package
+dist: clean
 	@echo "$(BOLD)Building package$(RESET)"
 	@python setup.py sdist bdist_wheel
 
@@ -65,6 +66,12 @@ tests:  ## Run tests for the isshub project.
 	@echo "$(BOLD)Running tests$(RESET)"
 	@## we ignore error 5 from pytest meaning there is no test to run
 	@pytest || ( ERR=$$?; if [ $${ERR} -eq 5 ]; then (exit 0); else (exit $${ERR}); fi )
+
+.PHONY: tests-nocov
+tests-nocov:  ## Run tests for the isshub project without coverage.
+	@echo "$(BOLD)Running tests (without coverage)$(RESET)"
+	@## we ignore error 5 from pytest meaning there is no test to run
+	@pytest --no-cov || ( ERR=$$?; if [ $${ERR} -eq 5 ]; then (exit 0); else (exit $${ERR}); fi )
 
 .PHONY: lint
 lint:  ## Run all linters (check-isort, check-black, mypy, flake8, pylint)

--- a/README.rst
+++ b/README.rst
@@ -453,6 +453,31 @@ Coding
 Domain
 ======
 
+As said previously, I'll use Domain Driven Development, at least some parts, not sure yet.
+
+The first step is to have a `isshub.domain` package.
+
+It will contain some sub-packages:
+
+contexts
+--------
+
+Bounded contexts are used to separate groups of things that work together but independent of other contexts.
+
+The contexts hold some entities, objects that have a distinct identity.
+
+The contexts are:
+
+core
+''''
+
+The `core` context will hold the "core" domaines, around repositories, issues, code requests...
+
+Its entities are:
+
+Repository
+    Repositories are the central entity of the whole isshub project. Everything is tied to them, at one level or another.
+
 Fetching
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -471,12 +471,14 @@ The contexts are:
 core
 ''''
 
-The `core` context will hold the "core" domaines, around repositories, issues, code requests...
+The `core` context will hold the "core" domain, around repositories, issues, code requests...
 
 Its entities are:
 
 Repository
     Repositories are the central entity of the whole isshub project. Everything is tied to them, at one level or another.
+Namespace
+    A namespace is a place where repositories or other namespaces are stored.
 
 Fetching
 ========

--- a/isshub/domain/__init__.py
+++ b/isshub/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Package to handle isshub domain content."""

--- a/isshub/domain/contexts/__init__.py
+++ b/isshub/domain/contexts/__init__.py
@@ -1,0 +1,1 @@
+"""Package to handle isshub domain contexts."""

--- a/isshub/domain/contexts/core/__init__.py
+++ b/isshub/domain/contexts/core/__init__.py
@@ -1,0 +1,10 @@
+"""Package to handle isshub domain core context.
+
+The "core" context defines every models that are at the core of the project:
+
+- repositories
+- issues
+- commits
+- ...
+
+"""

--- a/isshub/domain/contexts/core/entities/__init__.py
+++ b/isshub/domain/contexts/core/entities/__init__.py
@@ -1,0 +1,1 @@
+"""Package to handle isshub entities for domain core context."""

--- a/isshub/domain/contexts/core/entities/__init__.py
+++ b/isshub/domain/contexts/core/entities/__init__.py
@@ -1,1 +1,10 @@
 """Package to handle isshub entities for domain core context."""
+
+# Order is important so we disable isort for this file
+# isort:skip_file
+
+# Stop flake8 warning us than these imports are not used
+# flake8: noqa
+
+from .namespace import Namespace
+from .repository import Repository

--- a/isshub/domain/contexts/core/entities/namespace/__init__.py
+++ b/isshub/domain/contexts/core/entities/namespace/__init__.py
@@ -1,0 +1,52 @@
+"""Package defining the ``Namespace`` entity."""
+
+from typing import Optional
+
+from isshub.domain.utils.entity import (
+    BaseModelWithId,
+    optional_field,
+    required_field,
+    validated,
+)
+
+
+@validated()  # type: ignore
+class _Namespace(BaseModelWithId):
+    """A namespace can contain namespace and repositories.
+
+    Notes
+    -----
+    This is a base class, used by `Namespace` to be able to have a self-reference for the type
+    of the `namespace` field.
+
+    Attributes
+    ----------
+    id : int
+        The unique identifier of the namespace
+    name : str
+        The name of the namespace. Unique in its parent namespace.
+    namespace : Optional[Namespace]
+        Where the namespace can be found.
+
+    """
+
+    name: str = required_field(str)  # type: ignore
+    namespace = None
+
+
+@validated()  # type: ignore
+class Namespace(_Namespace):
+    """A namespace can contain namespace and repositories.
+
+    Attributes
+    ----------
+    id : int
+        The unique identifier of the namespace
+    name : str
+        The name of the namespace. Unique in its parent namespace.
+    namespace : Optional[str]
+        Where the namespace can be found.
+
+    """
+
+    namespace: Optional[_Namespace] = optional_field(_Namespace)  # type: ignore

--- a/isshub/domain/contexts/core/entities/namespace/__init__.py
+++ b/isshub/domain/contexts/core/entities/namespace/__init__.py
@@ -1,5 +1,6 @@
 """Package defining the ``Namespace`` entity."""
 
+import enum
 from typing import Optional
 
 from isshub.domain.utils.entity import (
@@ -8,6 +9,14 @@ from isshub.domain.utils.entity import (
     required_field,
     validated,
 )
+
+
+class NamespaceKind(enum.Enum):
+    """All the available kinds of namespace."""
+
+    ORGANIZATION = "Organization"
+    TEAM = "Team"
+    GROUP = "Group"
 
 
 @validated()  # type: ignore
@@ -27,11 +36,14 @@ class _Namespace(BaseModelWithId):
         The name of the namespace. Unique in its parent namespace.
     namespace : Optional[Namespace]
         Where the namespace can be found.
+    kind : NamespaceKind
+        The kind of namespace.
 
     """
 
     name: str = required_field(str)  # type: ignore
     namespace = None
+    kind: NamespaceKind = required_field(NamespaceKind)  # type: ignore
 
 
 @validated()  # type: ignore
@@ -46,6 +58,8 @@ class Namespace(_Namespace):
         The name of the namespace. Unique in its parent namespace.
     namespace : Optional[str]
         Where the namespace can be found.
+    kind : NamespaceKind
+        The kind of namespace.
 
     """
 

--- a/isshub/domain/contexts/core/entities/namespace/__init__.py
+++ b/isshub/domain/contexts/core/entities/namespace/__init__.py
@@ -38,12 +38,15 @@ class _Namespace(BaseModelWithId):
         Where the namespace can be found.
     kind : NamespaceKind
         The kind of namespace.
+    description : Optional[str]
+        The description of the namespace.
 
     """
 
     name: str = required_field(str)  # type: ignore
     namespace = None
     kind: NamespaceKind = required_field(NamespaceKind)  # type: ignore
+    description: str = optional_field(str)  # type: ignore
 
 
 @validated()  # type: ignore
@@ -60,6 +63,8 @@ class Namespace(_Namespace):
         Where the namespace can be found.
     kind : NamespaceKind
         The kind of namespace.
+    description : Optional[str]
+        The description of the namespace.
 
     """
 

--- a/isshub/domain/contexts/core/entities/namespace/features/describe.feature
+++ b/isshub/domain/contexts/core/entities/namespace/features/describe.feature
@@ -35,3 +35,15 @@ Feature: Describing a Namespace
     Scenario: A Namespace namespace can be None
         Given a Namespace
         Then its namespace can be None
+
+    Scenario: A Namespace has a kind
+        Given a Namespace
+        Then it must have a field named kind
+
+    Scenario: A Namespace kind is a NamespaceKind
+        Given a Namespace
+        Then its kind must be a NamespaceKind
+
+    Scenario: A Namespace kind cannot be None
+        Given a Namespace
+        Then its kind cannot be None

--- a/isshub/domain/contexts/core/entities/namespace/features/describe.feature
+++ b/isshub/domain/contexts/core/entities/namespace/features/describe.feature
@@ -24,6 +24,18 @@ Feature: Describing a Namespace
         Given a Namespace
         Then its name cannot be None
 
+    Scenario: A Namespace has a description
+        Given a Namespace
+        Then it must have a field named description
+
+    Scenario: A Namespace description is a string
+        Given a Namespace
+        Then its description must be a string
+
+    Scenario: A Namespace description can be None
+        Given a Namespace
+        Then its description can be None
+
     Scenario: A Namespace has a namespace
         Given a Namespace
         Then it must have a field named namespace

--- a/isshub/domain/contexts/core/entities/namespace/features/describe.feature
+++ b/isshub/domain/contexts/core/entities/namespace/features/describe.feature
@@ -1,0 +1,37 @@
+Feature: Describing a Namespace
+
+    Scenario: A Namespace has an id
+        Given a Namespace
+        Then it must have a field named id
+
+    Scenario: A Namespace id is a positive integer
+        Given a Namespace
+        Then its id must be a positive integer
+
+    Scenario: A Namespace id cannot be None
+        Given a Namespace
+        Then its id cannot be None
+
+    Scenario: A Namespace has a name
+        Given a Namespace
+        Then it must have a field named name
+
+    Scenario: A Namespace name is a string
+        Given a Namespace
+        Then its name must be a string
+
+    Scenario: A Namespace name cannot be None
+        Given a Namespace
+        Then its name cannot be None
+
+    Scenario: A Namespace has a namespace
+        Given a Namespace
+        Then it must have a field named namespace
+
+    Scenario: A Namespace namespace is a Namespace
+        Given a Namespace
+        Then its namespace must be a Namespace
+
+    Scenario: A Namespace namespace can be None
+        Given a Namespace
+        Then its namespace can be None

--- a/isshub/domain/contexts/core/entities/namespace/tests/__init__.py
+++ b/isshub/domain/contexts/core/entities/namespace/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Package holding the tests for the ``Namespace`` core entity."""

--- a/isshub/domain/contexts/core/entities/namespace/tests/factories.py
+++ b/isshub/domain/contexts/core/entities/namespace/tests/factories.py
@@ -2,7 +2,12 @@
 
 import factory
 
-from isshub.domain.contexts.core.entities.namespace import Namespace
+from faker_enum import EnumProvider
+
+from isshub.domain.contexts.core.entities.namespace import Namespace, NamespaceKind
+
+
+factory.Faker.add_provider(EnumProvider)
 
 
 class NamespaceFactory(factory.Factory):
@@ -15,3 +20,4 @@ class NamespaceFactory(factory.Factory):
 
     id = factory.Faker("pyint", min=1)
     name = factory.Faker("pystr", min_chars=2)
+    kind = factory.Faker("enum", enum_cls=NamespaceKind)

--- a/isshub/domain/contexts/core/entities/namespace/tests/factories.py
+++ b/isshub/domain/contexts/core/entities/namespace/tests/factories.py
@@ -1,0 +1,17 @@
+"""Module defining factories for the Namespace core entity."""
+
+import factory
+
+from isshub.domain.contexts.core.entities.namespace import Namespace
+
+
+class NamespaceFactory(factory.Factory):
+    """Factory for the ``Namespace`` core entity."""
+
+    class Meta:
+        """Factory config."""
+
+        model = Namespace
+
+    id = factory.Faker("pyint", min=1)
+    name = factory.Faker("pystr", min_chars=2)

--- a/isshub/domain/contexts/core/entities/namespace/tests/fixtures.py
+++ b/isshub/domain/contexts/core/entities/namespace/tests/fixtures.py
@@ -1,0 +1,36 @@
+"""Module defining fixtures for the Namespace core entity."""
+
+
+from typing import Type
+
+from pytest import fixture
+
+from isshub.domain.contexts.core.entities.namespace import Namespace
+
+from .factories import NamespaceFactory
+
+
+@fixture  # type: ignore
+def namespace_factory() -> Type[NamespaceFactory]:
+    """Fixture to return the factory to create a ``Namespace``.
+
+    Returns
+    -------
+    Type[NamespaceFactory]
+        The ``NamespaceFactory`` class.
+
+    """
+    return NamespaceFactory
+
+
+@fixture  # type: ignore
+def namespace() -> Namespace:
+    """Fixture to return a ``Namespace``.
+
+    Returns
+    -------
+    Namespace
+        The created ``Namespace``
+
+    """
+    return NamespaceFactory()

--- a/isshub/domain/contexts/core/entities/namespace/tests/test_describe.py
+++ b/isshub/domain/contexts/core/entities/namespace/tests/test_describe.py
@@ -4,6 +4,7 @@ import pytest
 from pytest import mark
 from pytest_bdd import given, parsers, scenario, scenarios, then
 
+from isshub.domain.contexts.core.entities.namespace import NamespaceKind
 from isshub.domain.utils.testing.validation import (
     check_field,
     check_field_not_nullable,
@@ -34,6 +35,15 @@ def test_namespace_name_is_a_string(value, exception):
 )
 @scenario("../features/describe.feature", "A Namespace namespace is a Namespace")
 def test_namespace_namespace_is_a_namespace(value, exception):
+    pass
+
+
+@mark.parametrize(
+    ["value", "exception"],
+    [(NamespaceKind.GROUP, None), ("foo", TypeError), (1, TypeError)],
+)
+@scenario("../features/describe.feature", "A Namespace kind is a NamespaceKind")
+def test_namespace_kind_is_a_namespacekind(value, exception):
     pass
 
 

--- a/isshub/domain/contexts/core/entities/namespace/tests/test_describe.py
+++ b/isshub/domain/contexts/core/entities/namespace/tests/test_describe.py
@@ -47,6 +47,12 @@ def test_namespace_kind_is_a_namespacekind(value, exception):
     pass
 
 
+@mark.parametrize(["value", "exception"], string_only)
+@scenario("../features/describe.feature", "A Namespace description is a string")
+def test_namespace_description_is_a_string(value, exception):
+    pass
+
+
 scenarios("../features/describe.feature")
 
 

--- a/isshub/domain/contexts/core/entities/namespace/tests/test_describe.py
+++ b/isshub/domain/contexts/core/entities/namespace/tests/test_describe.py
@@ -1,0 +1,72 @@
+"""Module holding BDD tests for isshub Namespace core entity."""
+
+import pytest
+from pytest import mark
+from pytest_bdd import given, parsers, scenario, scenarios, then
+
+from isshub.domain.utils.testing.validation import (
+    check_field,
+    check_field_not_nullable,
+    check_field_nullable,
+    check_field_value,
+    positive_integer_only,
+    string_only,
+)
+
+from .fixtures import namespace, namespace_factory
+
+
+@mark.parametrize(["value", "exception"], positive_integer_only)
+@scenario("../features/describe.feature", "A Namespace id is a positive integer")
+def test_namespace_id_is_a_positive_integer(value, exception):
+    pass
+
+
+@mark.parametrize(["value", "exception"], string_only)
+@scenario("../features/describe.feature", "A Namespace name is a string")
+def test_namespace_name_is_a_string(value, exception):
+    pass
+
+
+@mark.parametrize(
+    ["value", "exception"],
+    [(pytest.lazy_fixture("namespace"), None), ("foo", TypeError), (1, TypeError)],
+)
+@scenario("../features/describe.feature", "A Namespace namespace is a Namespace")
+def test_namespace_namespace_is_a_namespace(value, exception):
+    pass
+
+
+scenarios("../features/describe.feature")
+
+
+@given("a Namespace")
+def namespace(namespace_factory):
+    return namespace_factory()
+
+
+@then(parsers.parse("it must have a field named {field_name:w}"))
+def namespace_has_field(namespace, field_name):
+    check_field(namespace, field_name)
+
+
+@then(parsers.parse("its {field_name:w} must be a {field_type}"))
+def namespace_field_is_of_a_certain_type(
+    namespace_factory,
+    field_name,
+    field_type,
+    # next args are for parametrize
+    value,
+    exception,
+):
+    check_field_value(namespace_factory, field_name, value, exception)
+
+
+@then(parsers.parse("its {field_name:w} cannot be none"))
+def namespace_field_cannot_be_none(namespace_factory, field_name):
+    check_field_not_nullable(namespace_factory, field_name)
+
+
+@then(parsers.parse("its {field_name:w} can be none"))
+def namespace_field_can_be_none(namespace_factory, field_name):
+    check_field_nullable(namespace_factory, field_name)

--- a/isshub/domain/contexts/core/entities/repository/__init__.py
+++ b/isshub/domain/contexts/core/entities/repository/__init__.py
@@ -1,10 +1,10 @@
 """Package defining the ``Repository`` entity."""
 
-from dataclasses import dataclass
+from isshub.domain.utils.entity import BaseModelWithId, required_field, validated
 
 
-@dataclass
-class Repository:
+@validated()  # type: ignore
+class Repository(BaseModelWithId):
     """A repository holds code, issues, code requests...
 
     Attributes
@@ -18,8 +18,5 @@ class Repository:
 
     """
 
-    __slots__ = ["id", "name", "namespace"]
-
-    id: int
-    name: str
-    namespace: str
+    name: str = required_field(str)  # type: ignore
+    namespace: str = required_field(str)  # type: ignore

--- a/isshub/domain/contexts/core/entities/repository/__init__.py
+++ b/isshub/domain/contexts/core/entities/repository/__init__.py
@@ -1,5 +1,6 @@
 """Package defining the ``Repository`` entity."""
 
+from isshub.domain.contexts.core.entities.namespace import Namespace
 from isshub.domain.utils.entity import BaseModelWithId, required_field, validated
 
 
@@ -13,10 +14,10 @@ class Repository(BaseModelWithId):
         The unique identifier of the repository
     name : str
         The name of the repository. Unique in its namespace.
-    namespace : str
+    namespace : Namespace
         Where the repository can be found.
 
     """
 
     name: str = required_field(str)  # type: ignore
-    namespace: str = required_field(str)  # type: ignore
+    namespace: Namespace = required_field(Namespace)  # type: ignore

--- a/isshub/domain/contexts/core/entities/repository/__init__.py
+++ b/isshub/domain/contexts/core/entities/repository/__init__.py
@@ -1,0 +1,25 @@
+"""Package defining the ``Repository`` entity."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Repository:
+    """A repository holds code, issues, code requests...
+
+    Attributes
+    ----------
+    id : int
+        The unique identifier of the repository
+    name : str
+        The name of the repository. Unique in its namespace.
+    namespace : str
+        Where the repository can be found.
+
+    """
+
+    __slots__ = ["id", "name", "namespace"]
+
+    id: int
+    name: str
+    namespace: str

--- a/isshub/domain/contexts/core/entities/repository/features/describe.feature
+++ b/isshub/domain/contexts/core/entities/repository/features/describe.feature
@@ -28,9 +28,9 @@ Feature: Describing a Repository
         Given a Repository
         Then it must have a field named namespace
 
-    Scenario: A Repository namespace is a string
+    Scenario: A Repository namespace is a Namespace
         Given a Repository
-        Then its namespace must be a string
+        Then its namespace must be a Namespace
 
     Scenario: A Repository namespace cannot be None
         Given a Repository

--- a/isshub/domain/contexts/core/entities/repository/features/describe.feature
+++ b/isshub/domain/contexts/core/entities/repository/features/describe.feature
@@ -4,10 +4,34 @@ Feature: Describing a Repository
         Given a Repository
         Then it must have a field named id
 
+    Scenario: A Repository id is a positive integer
+        Given a Repository
+        Then its id must be a positive integer
+
+    Scenario: A Repository id cannot be None
+        Given a Repository
+        Then its id cannot be None
+
     Scenario: A Repository has a name
         Given a Repository
         Then it must have a field named name
 
+    Scenario: A Repository name is a string
+        Given a Repository
+        Then its name must be a string
+
+    Scenario: A Repository name cannot be None
+        Given a Repository
+        Then its name cannot be None
+
     Scenario: A Repository has a namespace
         Given a Repository
         Then it must have a field named namespace
+
+    Scenario: A Repository namespace is a string
+        Given a Repository
+        Then its namespace must be a string
+
+    Scenario: A Repository namespace cannot be None
+        Given a Repository
+        Then its namespace cannot be None

--- a/isshub/domain/contexts/core/entities/repository/features/describe.feature
+++ b/isshub/domain/contexts/core/entities/repository/features/describe.feature
@@ -1,0 +1,13 @@
+Feature: Describing a Repository
+
+    Scenario: A Repository has an id
+        Given a Repository
+        Then it must have a field named id
+
+    Scenario: A Repository has a name
+        Given a Repository
+        Then it must have a field named name
+
+    Scenario: A Repository has a namespace
+        Given a Repository
+        Then it must have a field named namespace

--- a/isshub/domain/contexts/core/entities/repository/tests/__init__.py
+++ b/isshub/domain/contexts/core/entities/repository/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Package holding the tests for the ``Repository`` core entity."""

--- a/isshub/domain/contexts/core/entities/repository/tests/factories.py
+++ b/isshub/domain/contexts/core/entities/repository/tests/factories.py
@@ -1,0 +1,18 @@
+"""Module defining factories for the Repository core entity."""
+
+import factory
+
+from isshub.domain.contexts.core.entities.repository import Repository
+
+
+class RepositoryFactory(factory.Factory):
+    """Factory for the ``Repository`` core entity."""
+
+    class Meta:
+        """Factory config."""
+
+        model = Repository
+
+    id = factory.Faker("pyint", min=1)
+    name = factory.Faker("pystr", min_chars=2)
+    namespace = factory.Faker("pystr", min_chars=2)

--- a/isshub/domain/contexts/core/entities/repository/tests/factories.py
+++ b/isshub/domain/contexts/core/entities/repository/tests/factories.py
@@ -4,6 +4,8 @@ import factory
 
 from isshub.domain.contexts.core.entities.repository import Repository
 
+from ...namespace.tests.factories import NamespaceFactory
+
 
 class RepositoryFactory(factory.Factory):
     """Factory for the ``Repository`` core entity."""
@@ -15,4 +17,4 @@ class RepositoryFactory(factory.Factory):
 
     id = factory.Faker("pyint", min=1)
     name = factory.Faker("pystr", min_chars=2)
-    namespace = factory.Faker("pystr", min_chars=2)
+    namespace = factory.SubFactory(NamespaceFactory)

--- a/isshub/domain/contexts/core/entities/repository/tests/fixtures.py
+++ b/isshub/domain/contexts/core/entities/repository/tests/fixtures.py
@@ -1,0 +1,19 @@
+"""Module defining fixtures for the Repository core entity."""
+
+
+from pytest import fixture
+
+from .factories import RepositoryFactory
+
+
+@fixture
+def repository_factory():
+    """Fixture to return the factory to create a ``Repository``.
+
+    Returns
+    -------
+    Type[RepositoryFactory]
+        The ``RepositoryFactory`` class.
+
+    """
+    return RepositoryFactory

--- a/isshub/domain/contexts/core/entities/repository/tests/test_describe.py
+++ b/isshub/domain/contexts/core/entities/repository/tests/test_describe.py
@@ -1,0 +1,18 @@
+"""Module holding BDD tests for isshub Repository core entity."""
+
+from pytest_bdd import given, parsers, scenarios, then
+
+from .fixtures import repository_factory
+
+
+scenarios("../features/describe.feature")
+
+
+@given("a Repository")
+def repository(repository_factory):
+    return repository_factory()
+
+
+@then(parsers.parse("it must have a field named {field_name:w}"))
+def repository_has_field(repository, field_name):
+    assert hasattr(repository, field_name)

--- a/isshub/domain/contexts/core/entities/repository/tests/test_describe.py
+++ b/isshub/domain/contexts/core/entities/repository/tests/test_describe.py
@@ -1,8 +1,30 @@
 """Module holding BDD tests for isshub Repository core entity."""
 
-from pytest_bdd import given, parsers, scenarios, then
+import pytest
+from pytest import mark
+from pytest_bdd import given, parsers, scenario, scenarios, then
+
+from isshub.domain.utils.testing.validation import positive_integer_only, string_only
 
 from .fixtures import repository_factory
+
+
+@mark.parametrize(["value", "exception"], positive_integer_only)
+@scenario("../features/describe.feature", "A Repository id is a positive integer")
+def test_repository_id_is_a_positive_integer(value, exception):
+    pass
+
+
+@mark.parametrize(["value", "exception"], string_only)
+@scenario("../features/describe.feature", "A Repository name is a string")
+def test_repository_name_is_a_string(value, exception):
+    pass
+
+
+@mark.parametrize(["value", "exception"], string_only)
+@scenario("../features/describe.feature", "A Repository namespace is a string")
+def test_repository_namespace_is_a_string(value, exception):
+    pass
 
 
 scenarios("../features/describe.feature")
@@ -16,3 +38,45 @@ def repository(repository_factory):
 @then(parsers.parse("it must have a field named {field_name:w}"))
 def repository_has_field(repository, field_name):
     assert hasattr(repository, field_name)
+
+
+@then(parsers.parse("its {field_name:w} must be a {field_type}"))
+def repository_field_is_of_a_certain_type(
+    repository_factory,
+    field_name,
+    field_type,
+    # next args are for parametrize
+    value,
+    exception,
+):
+    # `field_type` is ignored: the type must be managed via parametrize at the
+    # scenario level, passing values to test and the exception that must be raised
+    # in case of failure, or `None` if the value is valid
+    if exception:
+        # When creating an instance
+        with pytest.raises(exception):
+            repository_factory(**{field_name: value})
+        # When updating the value
+        repository = repository_factory()
+        setattr(repository, field_name, value)
+        with pytest.raises(exception):
+            repository.validate()
+    else:
+        # When creating an instance
+        repository_factory(**{field_name: value})
+        # When updating the value
+        repository = repository_factory()
+        setattr(repository, field_name, value)
+        repository.validate()
+
+
+@then(parsers.parse("its {field_name:w} cannot be none"))
+def repository_field_cannot_be_none(repository_factory, field_name):
+    # When creating an instance
+    with pytest.raises(TypeError):
+        repository_factory(**{field_name: None})
+    # When updating the value
+    repository = repository_factory()
+    repository.id = None
+    with pytest.raises(TypeError):
+        repository.validate()

--- a/isshub/domain/contexts/core/entities/repository/tests/test_describe.py
+++ b/isshub/domain/contexts/core/entities/repository/tests/test_describe.py
@@ -4,8 +4,15 @@ import pytest
 from pytest import mark
 from pytest_bdd import given, parsers, scenario, scenarios, then
 
-from isshub.domain.utils.testing.validation import positive_integer_only, string_only
+from isshub.domain.utils.testing.validation import (
+    check_field,
+    check_field_not_nullable,
+    check_field_value,
+    positive_integer_only,
+    string_only,
+)
 
+from ...namespace.tests.fixtures import namespace
 from .fixtures import repository_factory
 
 
@@ -21,9 +28,12 @@ def test_repository_name_is_a_string(value, exception):
     pass
 
 
-@mark.parametrize(["value", "exception"], string_only)
-@scenario("../features/describe.feature", "A Repository namespace is a string")
-def test_repository_namespace_is_a_string(value, exception):
+@mark.parametrize(
+    ["value", "exception"],
+    [(pytest.lazy_fixture("namespace"), None), ("foo", TypeError), (1, TypeError)],
+)
+@scenario("../features/describe.feature", "A Repository namespace is a Namespace")
+def test_repository_namespace_is_a_namespace(value, exception):
     pass
 
 
@@ -37,7 +47,7 @@ def repository(repository_factory):
 
 @then(parsers.parse("it must have a field named {field_name:w}"))
 def repository_has_field(repository, field_name):
-    assert hasattr(repository, field_name)
+    check_field(repository, field_name)
 
 
 @then(parsers.parse("its {field_name:w} must be a {field_type}"))
@@ -49,34 +59,9 @@ def repository_field_is_of_a_certain_type(
     value,
     exception,
 ):
-    # `field_type` is ignored: the type must be managed via parametrize at the
-    # scenario level, passing values to test and the exception that must be raised
-    # in case of failure, or `None` if the value is valid
-    if exception:
-        # When creating an instance
-        with pytest.raises(exception):
-            repository_factory(**{field_name: value})
-        # When updating the value
-        repository = repository_factory()
-        setattr(repository, field_name, value)
-        with pytest.raises(exception):
-            repository.validate()
-    else:
-        # When creating an instance
-        repository_factory(**{field_name: value})
-        # When updating the value
-        repository = repository_factory()
-        setattr(repository, field_name, value)
-        repository.validate()
+    check_field_value(repository_factory, field_name, value, exception)
 
 
 @then(parsers.parse("its {field_name:w} cannot be none"))
 def repository_field_cannot_be_none(repository_factory, field_name):
-    # When creating an instance
-    with pytest.raises(TypeError):
-        repository_factory(**{field_name: None})
-    # When updating the value
-    repository = repository_factory()
-    repository.id = None
-    with pytest.raises(TypeError):
-        repository.validate()
+    check_field_not_nullable(repository_factory, field_name)

--- a/isshub/domain/utils/__init__.py
+++ b/isshub/domain/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utils for isshub domain code."""

--- a/isshub/domain/utils/entity.py
+++ b/isshub/domain/utils/entity.py
@@ -1,0 +1,174 @@
+"""Package to handle isshub entities validation.
+
+It is an adapter over the ``attrs`` external dependency.
+
+"""
+
+# type: ignore
+
+import attr
+
+
+def optional_field(field_type):
+    """Define an optional field of the specified `field_type`.
+
+    Parameters
+    ----------
+    field_type : type
+        The expected type of the field when not ``None``.
+
+    Returns
+    -------
+    Any
+        An ``attrs`` attribute, with a default value set to ``None``, and a validator checking
+        that this field is optional and, if set, of the correct type.
+
+    """
+    return attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(field_type)),
+    )
+
+
+def required_field(field_type):
+    """Define a required field of the specified `field_type`.
+
+    Parameters
+    ----------
+    field_type : type
+        The expected type of the field..
+
+    Returns
+    -------
+    Any
+        An ``attrs`` attribute, and a validator checking that this field is of the correct type.
+
+    """
+    return attr.ib(validator=attr.validators.instance_of(field_type))
+
+
+def validated():
+    """Decorate an entity to handle validation.
+
+    This will let ``attrs`` manage the class, using slots for fields.
+
+    Returns
+    -------
+    type
+        The decorated class.
+
+    """
+    return attr.s(slots=True)
+
+
+def field_validator(field):
+    """Decorate an entity method to make it a validator of the given `field`.
+
+    Parameters
+    ----------
+    field : Any
+        The field to validate.
+
+    Returns
+    -------
+    Callable
+        The decorated method.
+
+    """
+    return field.validator
+
+
+def validate_instance(instance):
+    """Validate a whole instance.
+
+    Parameters
+    ----------
+    instance : Any
+        The instance to validate.
+
+    Raises
+    ------
+    TypeError, ValueError
+        If a field in the `instance` is not valid.
+
+    """
+    attr.validate(instance)
+
+
+def validate_positive_integer(value, none_allowed, display_name):
+    """Validate that the given `value` is a positive integer (``None`` accepted if `none_allowed`).
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate as a positive integer.
+    none_allowed : bool
+        If ``True``, the value can be ``None``. If ``False``, the value must be a positive integer.
+    display_name : str
+        The name of the field to display in errors.
+
+    Raises
+    ------
+    TypeError
+        If `value` is not of type ``int``.
+    ValueError
+        If `value` is not a positive integer (ie > 0), or ``None`` if `none_allowed` is ``True``.
+
+    """
+    if none_allowed and value is None:
+        return
+
+    if not isinstance(value, int):
+        raise TypeError(f"{display_name} must be a positive integer")
+    if value <= 0:
+        raise ValueError(f"{display_name} must be a positive integer")
+
+
+@validated()
+class BaseModel:
+    """A base model without any field, that is able to validate itself."""
+
+    def validate(self) -> None:
+        """Validate all fields of the current instance.
+
+        Raises
+        ------
+        TypeError, ValueError
+            If a field is not valid.
+
+        """
+        validate_instance(self)
+
+
+@validated()
+class BaseModelWithId(BaseModel):
+    """A base model with an ``id``, that is able to validate itself.
+
+    Attributes
+    ----------
+    id : int
+        The identifier of the instance. Validated to be a positive integer.
+
+    """
+
+    id: int = required_field(int)
+
+    @field_validator(id)
+    def id_is_positive_integer(  # noqa  # pylint: disable=unused-argument
+        self, field, value
+    ):
+        """Validate that the ``id`` field is a positive integer.
+
+        Parameters
+        ----------
+        field : Any
+            The field to validate. Passed via the ``@field_validator`` decorator.
+        value : Any
+            The value to validate for the `field`.
+
+        """
+        validate_positive_integer(
+            value=value,
+            none_allowed=False,
+            display_name=f"{self.__class__.__name__}.id",
+        )

--- a/isshub/domain/utils/testing/__init__.py
+++ b/isshub/domain/utils/testing/__init__.py
@@ -1,1 +1,8 @@
 """Utils for isshub domain tests."""
+
+try:
+    import pytest
+except ImportError:
+    pass
+else:
+    pytest.register_assert_rewrite("isshub.domain.utils.testing.validation")

--- a/isshub/domain/utils/testing/__init__.py
+++ b/isshub/domain/utils/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Utils for isshub domain tests."""

--- a/isshub/domain/utils/testing/validation.py
+++ b/isshub/domain/utils/testing/validation.py
@@ -1,6 +1,11 @@
-"""Validation helpers for BDD tests for isshub entity models."""
+"""Validation helpers for BDD tests for isshub entities."""
 
 from typing import Any, List, Optional, Tuple, Type
+
+import pytest
+from factory import Factory
+
+from isshub.domain.utils.entity import BaseModel
 
 
 ValuesValidation = List[Tuple[Any, Optional[Type[Exception]]]]
@@ -22,3 +27,138 @@ no_zero: ValuesValidation = [(0, ValueError)]
 positive_integer_only: ValuesValidation = integer_only + no_zero
 
 string_only: ValuesValidation = [("foo", None), (1, TypeError), (-0.1, TypeError)]
+
+
+def check_field(obj: BaseModel, field_name: str) -> None:
+    """Assert that the given `obj` has an attribute named `field_name`.
+
+    Parameters
+    ----------
+    obj : BaseModel
+        The object to test
+    field_name : str
+        The field name to search for
+
+    Raises
+    ------
+    AssertionError
+        If `obj` does not contain any attribute named `field_name`
+
+    """
+    assert hasattr(obj, field_name)
+
+
+def check_field_value(
+    factory: Type[Factory],
+    field_name: str,
+    value: Any,
+    exception: Optional[Type[Exception]],
+    **factory_kwargs: Any,
+) -> None:
+    """Assert that an object can or cannot have a specific value for a specific field.
+
+    Parameters
+    ----------
+    factory : Type[Factory]
+        The factory to use to create the object to test
+    field_name : str
+        The name of the field to check
+    value : Any
+        The value to set to the field
+    exception :  Optional[Type[Exception]]
+        The exception expected to be raised. If ``None``, no exception is expected to be raised.
+    factory_kwargs : Any
+        Any kwargs to pass to the factory to create the object
+
+    Raises
+    ------
+    AssertionError
+        If an exception is raised when setting the `value` to the field when creating or updating
+        an object (when calling ``validate`` in case of updating), and `exception` is ``None``,
+        or if no exception is raised if `exception` is not ``None`` (or the wrong exception).
+
+    """
+    if exception:
+        # When creating an instance
+        with pytest.raises(exception):
+            factory(**{field_name: value}, **factory_kwargs)
+        # When updating the value
+        obj = factory(**factory_kwargs)
+        setattr(obj, field_name, value)
+        with pytest.raises(exception):
+            obj.validate()
+    else:
+        # When creating an instance
+        factory(**{field_name: value}, **factory_kwargs)
+        # When updating the value
+        obj = factory(**factory_kwargs)
+        setattr(obj, field_name, value)
+        obj.validate()
+
+
+def check_field_not_nullable(
+    factory: Type[Factory], field_name: str, **factory_kwargs: Any
+) -> None:
+    """Assert that an object cannot have a specific field set to ``None``.
+
+    Parameters
+    ----------
+    factory : Type[Factory]
+        The factory to use to create the object to test
+    field_name : str
+        The name of the field to check
+    factory_kwargs : Any
+        Any kwargs to pass to the factory to create the object
+
+    Raises
+    ------
+    AssertionError
+        If the field can be set to ``None`` while creating or updating an object (when calling
+        ``validate`` in case of updating)
+
+    """
+    # When creating an instance
+    with pytest.raises(TypeError):
+        factory(**{field_name: None}, **factory_kwargs)
+
+    # When updating the value
+    obj = factory(**factory_kwargs)
+    setattr(obj, field_name, None)
+    with pytest.raises(TypeError):
+        obj.validate()
+
+
+def check_field_nullable(
+    factory: Type[Factory], field_name: str, **factory_kwargs: Any
+) -> None:
+    """Assert that an object can have a specific field set to ``None``.
+
+    Parameters
+    ----------
+    factory : Type[Factory]
+        The factory to use to create the object to test
+    field_name : str
+        The name of the field to check
+    factory_kwargs : Any
+        Any kwargs to pass to the factory to create the object
+
+    Raises
+    ------
+    AssertionError
+        If the field cannot be set to ``None`` while creating or updating an object (when calling
+        ``validate`` in case of updating)
+
+    """
+    # When creating an instance
+    try:
+        factory(**{field_name: None}, **factory_kwargs)
+    except TypeError:
+        pytest.fail(f"DID RAISE {TypeError}")
+
+    # When updating the value
+    obj = factory(**factory_kwargs)
+    setattr(obj, field_name, None)
+    try:
+        obj.validate()
+    except TypeError:
+        pytest.fail(f"DID RAISE {TypeError}")

--- a/isshub/domain/utils/testing/validation.py
+++ b/isshub/domain/utils/testing/validation.py
@@ -1,0 +1,24 @@
+"""Validation helpers for BDD tests for isshub entity models."""
+
+from typing import Any, List, Optional, Tuple, Type
+
+
+ValuesValidation = List[Tuple[Any, Optional[Type[Exception]]]]
+
+integer_only: ValuesValidation = [
+    ("foo", TypeError),
+    (-123, ValueError),
+    (-1.5, TypeError),
+    (-1, ValueError),
+    (-0.001, TypeError),
+    (0.001, TypeError),
+    (1, None),
+    (1.5, TypeError),
+    (123, None),
+]
+
+no_zero: ValuesValidation = [(0, ValueError)]
+
+positive_integer_only: ValuesValidation = integer_only + no_zero
+
+string_only: ValuesValidation = [("foo", None), (1, TypeError), (-0.1, TypeError)]

--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,tests
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,12 +28,15 @@ packages = find:
 [options.packages.find]
 exclude =
     tests
+    *.tests
+    *.tests.*
 [options.extras_require]
 dev =
     ipython
     mypy
     wheel
 tests =
+    factory-boy
     pytest
     pytest-bdd
     pytest-cov
@@ -116,7 +119,7 @@ exclude =
     dist/
     build/
     ci/
-    test_testing.py
+    test_*.py
 per-file-ignores =
     # ignore mypy missing annotations in tests
     test_*:T4

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ requires-python = >=3.7
 [options]
 zip_safe = True
 packages = find:
+install_requires =
+    attrs
 
 [options.packages.find]
 exclude =
@@ -82,6 +84,9 @@ warn_incomplete_stub = true
 [mypy-isshub.*.tests.*]
 ignore_errors = True
 
+[mypy-isshub.domain.utils.entity]
+ignore_errors = True
+
 [flake8]
 ignore =
     # Line too long: we let black manage it
@@ -124,6 +129,7 @@ per-file-ignores =
     # ignore mypy missing annotations in tests
     test_*:T4
     factories.py:T4
+    isshub/domain/utils/entity.py:T4
 
 [pycodestyle]
 max-line-length = 99

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ dev =
     mypy
     wheel
 tests =
+    faker
+    faker-enum
     factory-boy
     pytest
     pytest-bdd

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ tests =
     pytest
     pytest-bdd
     pytest-cov
+    pytest-lazy-fixture
     pytest-sugar
 lint=
     black


### PR DESCRIPTION
Abstract
========

Add the `core` domain context with the `Repository` and `Namespace` entities. Managed and validated via the `attrs` package, and tested vi a `pytest-bdd`

Motivation
==========

Domain Driven Developement is a great way to have separation of concerns.

Bounded contexts are used to separate groups of things that work together but independent of other contexts.

Entities are objects that have a distinct identity.

As we need to start somewhere, this commit introduce DDD with its first context and first entities, and test it using BDD.

Rationale
=========

As the code repositories are at the root of Isshub, this commit introduce the `Repository` as its first entity, in a `core` context that will also holds issues, code requests, etc...

Repositories exists in "namespaces" (group, organization, team...), so the `Namespace` is another entity added in this PR.

An entity must have a specific set of fields and this is defined and tested using BDD, in a `describe.feature` file (one for each entity)

We make pylint and flake8 ignore test files because:
- no need for documentation as the BDD decorators include what is done in a function
- fixture usage is "magic" so it generates some warnings
- we still enforce black and isort so it's enough for having good code

And finally we updated how tests are run in CI for built packages, now that tests are not in a main `tests` directory, but near the things they test. we also do a better exclusion of tests in the final build and added LICENSE and README.rst to it.