### PR TITLE
fix(faker): Handle change of `min` (to `min_value`) arg for `pyint`

### DIFF
--- a/isshub/domain/contexts/core/entities/namespace/tests/factories.py
+++ b/isshub/domain/contexts/core/entities/namespace/tests/factories.py
@@ -18,6 +18,6 @@ class NamespaceFactory(factory.Factory):
 
         model = Namespace
 
-    id = factory.Faker("pyint", min=1)
+    id = factory.Faker("pyint", min_value=1)
     name = factory.Faker("pystr", min_chars=2)
     kind = factory.Faker("enum", enum_cls=NamespaceKind)

--- a/isshub/domain/contexts/core/entities/repository/tests/factories.py
+++ b/isshub/domain/contexts/core/entities/repository/tests/factories.py
@@ -15,6 +15,6 @@ class RepositoryFactory(factory.Factory):
 
         model = Repository
 
-    id = factory.Faker("pyint", min=1)
+    id = factory.Faker("pyint", min_value=1)
     name = factory.Faker("pystr", min_chars=2)
     namespace = factory.SubFactory(NamespaceFactory)


### PR DESCRIPTION
Abstract
========

Replace `min` arg when calling `factory.Faker("pyint"...` with its new
`min_value` name.

Motivation
==========

The new argument name broke the tests.

Rationale
=========

N/A
