### PR TITLE
chore(make): Upgrade pip in `dev-upgrade` make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ dev:  ## Install the project in the current environment, with its dependencies, 
 
 .PHONY: dev-upgrade
 dev-upgrade:  ## Upgrade all default+dev dependencies defined in setup.cfg
+	@pip install --upgrade pip
 	@pip install --upgrade `python -c 'import setuptools; o = setuptools.config.read_configuration("setup.cfg")["options"]; print(" ".join(o["install_requires"] + o["extras_require"]["dev"] + o["extras_require"]["tests"] + o["extras_require"]["lint"] + o["extras_require"]["docs"]))'`
 	@pip install -e .
 	@$(MAKE) full-clean


### PR DESCRIPTION
Abstract
========

Ask pip to updated itself before upgrading other packages

Motivation
==========

Instead of having the message given by pip and having to do the upgrade
manually, it's a good idea to have it done automatically before
upgrading all other packages

Rationale
=========

N/A
