### PR TITLE
fix(docs): Fix two errors in doc and ensure CI will spot them in the future

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
           name: Build documentation
           command: |
             source ~/venv/bin/activate
-            make doc
+            make doc-strict
 
   # run check and tests for every commit in the history for which it is not already done
   check_every_commit:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ doc:  clean-doc ## Build the documentation
 	@echo "$(BOLD)Building documentation$(RESET)"
 	@cd docs && $(MAKE) html
 
+.PHONY: doc-strict docs-strict
+docs-strict: doc-strict  # we allow "doc-strict" and "docs-strict"
+doc-strict:  clean-doc ## Build the documentation but fail if a warning
+	@echo "$(BOLD)Building documentation (strict)$(RESET)"
+	@cd docs && sphinx-build -W -b html . _build
+
 .PHONY: clean-docs
 clean-docs: clean-doc  # we allow "clean-doc" and "clean-docs"
 clean-doc:  ## Clean the documentation directories

--- a/README.rst
+++ b/README.rst
@@ -469,7 +469,7 @@ The contexts hold some entities, objects that have a distinct identity.
 The contexts are:
 
 code_repository
-''''
+'''''''''''''''
 
 The `code_repository` context will hold things around repositories, issues, code requests...
 

--- a/docs/git_to_sphinx.py
+++ b/docs/git_to_sphinx.py
@@ -140,7 +140,7 @@ class RepositoryMining(RepositoryMiningBase):
             raise Exception("The path to the repo has to be of type 'string'")
 
     def get_git_repo(self):
-        path_repo = self._path_to_repo
+        path_repo = self._path_to_repo[0]
 
         if self._isremote(path_repo):
             # save in `self` to avoid premature destruction of the tmp directory


### PR DESCRIPTION
Abstract
========

- correct badly formatted README
- fix `git_to_sphinx` following `pydriller` upgrade
- add a `make doc-strict` command, used by the CI

Motivation
==========

Two problems were present but not detected in the documentation, only visible when looking at the documentation.
So we had to fix these issues and ensure that we can catch them early via the CI


Rationale
=========

`sphinx-build` accepts a `-W` argument that treats warnings as errors.

It's not possible to use it with the `make` commands of the docs
MakeFile, so we had to put the whole `sphinx-build` command in the `make
doc-strict` command.
