### PR TITLE
docs: Tweak doc rendering and add code examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
           name: Build documentation
           command: |
             source ~/venv/bin/activate
-            make doc-strict
+            GIT_TO_SPHINX_UPDATE_BRANCHES=TRUE make doc-strict
 
   # run check and tests for every commit in the history for which it is not already done
   check_every_commit:

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,3 +1,12 @@
+/* Hide class attributes because they are duplicate of the class vars found by napoleon plugins
+and those vars are more detailed.
+Side effect: If attributes are not defined in docstrings, they won't appear at all.
+ */
+dl.class > dd > dl.field-list ~ dl.attribute {
+	display: None;
+}
+
+/* Handle more levels of entries in the left sidebar */
 .wy-menu-vertical li.toctree-l3.current li.toctree-l4>ul,
 .wy-menu-vertical li.toctree-l4.current li.toctree-l5>ul,
 .wy-menu-vertical li.toctree-l5.current li.toctree-l6>ul,
@@ -24,7 +33,7 @@
 	display: block
 }
 .wy-menu-vertical li.toctree-l4.current li[class*="toctree-l"]>a{
-    padding: .4045em 5.663em;
+	padding: .4045em 5.663em;
 }
 .wy-menu-vertical li.toctree-l5>a{
 	padding-left: 6.663em !important;
@@ -52,12 +61,4 @@
 }
 .wy-menu-vertical li.toctree-l13>a{
 	padding-left: 14.663em !important;
-}
-
-/* Hide class attributes because they are duplicate of the class vars found by napoleon plugins
-and those vars are more detailed.
-Side effect: If attributes are not defined in docstrings, they won't appear at all.
- */
-dl.class > dd > dl.field-list ~ dl.attribute {
-	display: None;
 }

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -5,6 +5,33 @@ Side effect: If attributes are not defined in docstrings, they won't appear at a
 dl.class > dd > dl.field-list ~ dl.attribute {
 	display: None;
 }
+/* Package owning the current package/module, placed at the top right of the current package/module */
+.package-owner {
+	float: right;
+}
+/* Hide the real title and instead show our own with more text in it (to avoid polluting toctree with more text) */
+.package-or-module-title {
+	margin-top: 0;
+	font-weight: 700;
+	font-family: "Roboto Slab","ff-tisa-web-pro","Georgia",Arial,sans-serif;
+	font-size: 175%;
+}
+.package-owner ~ .section h1 {
+	display: none;
+}
+/* List of sub-packages/modules of the current package:
+	- Make the title "Subpackages"/"Submodules" not bold, and placed just before the list
+	- Add a left border to the list to make it visually match with the title
+ */
+p.rubric.package-sub {
+	margin-bottom: 0;
+	font-weight: normal;
+}
+p.rubric.package-sub + .toctree-wrapper {
+	border-left: solid #404040 1px;
+	margin-left: 6px;
+	padding-top: 6px;
+}
 
 /* Handle more levels of entries in the left sidebar */
 .wy-menu-vertical li.toctree-l3.current li.toctree-l4>ul,

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -36,6 +36,21 @@ p.rubric.package-sub + .toctree-wrapper {
 	margin-left: 6px;
 	padding-top: 6px;
 }
+/* Add emphasis to the first line of docstring of packages and modules */
+.package-or-module-title + .section > span.target:first-of-type + p,  /* package with no content */
+.package-or-module-title + .section > span + h1:first-of-type + p, /* package with content */
+.package-or-module-title ~ span.target:first-of-type + p {  /* module */
+	font-weight: 600;
+	font-style: italic;
+	font-size: larger;
+}
+/* Add emphasis to the first line of docstring of classes, methods and functions */
+dl.class > dd:first-of-type > p:nth-child(2),
+dl.method > dd:first-of-type > p:first-of-type,
+dl.function > dd:first-of-type > p:first-of-type {
+	font-weight: 600;
+	font-style: italic;
+}
 
 /* Handle more levels of entries in the left sidebar */
 .wy-menu-vertical li.toctree-l3.current li.toctree-l4>ul,

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -42,6 +42,10 @@ p.rubric.package-sub + .toctree-wrapper {
 	margin-left: 6px;
 	padding-top: 6px;
 }
+div#packages > h1 + .toctree-wrapper ul ul, p.package-sub  + .toctree-wrapper ul ul {
+    margin-top: 0;
+    margin-bottom: 0;
+}
 /* Add emphasis to the first line of docstring of packages and modules */
 .package-or-module-title + .section > span.target:first-of-type + p,  /* package with no content */
 .package-or-module-title + .section > span + h1:first-of-type + p, /* package with content */

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -9,9 +9,15 @@ Side effect: If attributes are not defined in docstrings, they won't appear at a
 dl.class > dd > dl.field-list ~ dl.attribute {
 	display: None;
 }
-/* Package owning the current package/module, placed at the top right of the current package/module */
-.package-owner {
+/* Package owning the current package/module and link to git history, placed at the top right of the current package/module */
+.package-side-info {
 	float: right;
+	text-align: right;
+}
+.package-side-info a:nth-child(2) { /* link "view git history", on its own line and smaller */
+	display: block;
+	font-size: smaller;
+	margin-top: 3px;
 }
 /* Hide the real title and instead show our own with more text in it (to avoid polluting toctree with more text) */
 .package-or-module-title {
@@ -20,7 +26,7 @@ dl.class > dd > dl.field-list ~ dl.attribute {
 	font-family: "Roboto Slab","ff-tisa-web-pro","Georgia",Arial,sans-serif;
 	font-size: 175%;
 }
-.package-owner ~ .section h1 {
+.package-side-info ~ .section h1 {
 	display: none;
 }
 /* List of sub-packages/modules of the current package:

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,3 +1,7 @@
+/* Hide "View page source" link (because it links to source used for search) */
+.wy-breadcrumbs-aside {
+	display: none !important;
+}
 /* Hide class attributes because they are duplicate of the class vars found by napoleon plugins
 and those vars are more detailed.
 Side effect: If attributes are not defined in docstrings, they won't appear at all.

--- a/docs/apidoc_templates/module.rst_t
+++ b/docs/apidoc_templates/module.rst_t
@@ -1,6 +1,7 @@
-.. rst-class:: package-owner
+.. rst-class:: package-side-info
 
    in :doc:`{{ basename.split('.')[:-1] | join(".") }} <{{ basename.split('.')[:-1] | join(".") }}>`
+   :doc:`View Git history </git/content/{{ basename.split('.') | join("/") }}.py>`
 
 {{ basename.split('.')[-1] | e | heading }}
 

--- a/docs/apidoc_templates/module.rst_t
+++ b/docs/apidoc_templates/module.rst_t
@@ -1,0 +1,15 @@
+.. rst-class:: package-owner
+
+   in :doc:`{{ basename.split('.')[:-1] | join(".") }} <{{ basename.split('.')[:-1] | join(".") }}>`
+
+{{ basename.split('.')[-1] | e | heading }}
+
+.. rst-class:: package-or-module-title
+
+   {{ ['"', basename.split('.')[-1] | e, '" module'] | join("") }}
+
+.. automodule:: {{ qualname }}
+{%- for option in automodule_options %}
+   :{{ option }}:
+{%- endfor %}
+

--- a/docs/apidoc_templates/package.rst_t
+++ b/docs/apidoc_templates/package.rst_t
@@ -1,0 +1,43 @@
+{%- macro automodule(modname, options) -%}
+.. automodule:: {{ modname }}
+{%- for option in options %}
+   :{{ option }}:
+{%- endfor %}
+{%- endmacro %}
+
+{%- macro toctree(docnames, section_name) -%}
+.. rubric:: {{ section_name }}
+   :class: package-sub
+
+.. toctree::
+{% for docname in docnames %}
+   {{ docname.split('.')[-1] }} <{{ docname }}>
+{%- endfor %}
+{%- endmacro %}
+
+
+.. rst-class:: package-owner
+
+   {% if '.' in pkgname %}in :doc:`{{ pkgname.split('.')[:-1] | join(".") }} <{{ pkgname.split('.')[:-1] | join(".") }}>`{% else %}(root){% endif %}
+
+
+.. rst-class:: package-or-module-title
+
+   {{ ['"', pkgname.split('.')[-1] | e, '" package'] | join("") }}
+
+{{ pkgname.split('.')[-1] | e | heading }}
+
+
+{%- if subpackages %}
+{{ toctree(subpackages, "Subpackages") }}
+{% endif %}
+
+{%- if submodules %}
+{{ toctree(submodules, "Submodules") }}
+{% endif %}
+
+{%- if not is_namespace %}
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}
+
+

--- a/docs/apidoc_templates/package.rst_t
+++ b/docs/apidoc_templates/package.rst_t
@@ -15,11 +15,10 @@
 {%- endfor %}
 {%- endmacro %}
 
-
-.. rst-class:: package-owner
+.. rst-class:: package-side-info
 
    {% if '.' in pkgname %}in :doc:`{{ pkgname.split('.')[:-1] | join(".") }} <{{ pkgname.split('.')[:-1] | join(".") }}>`{% else %}(root){% endif %}
-
+   :doc:`View Git history </git/content/{{ pkgname.split('.') | join("/") }}/__init__.py>`
 
 .. rst-class:: package-or-module-title
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,8 @@ def run_apidoc(_):
             "--force",
             "--module-first",
             "--separate",
+            "-d",  # maxdepth
+            "6",
             "--doc-project",
             "Packages",
             "--templatedir",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,6 +108,8 @@ def run_apidoc(_):
             "--force",
             "--module-first",
             "--separate",
+            "--doc-project",
+            "Packages",
             "--output-dir",
             source_path,
             output_path,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,17 +123,34 @@ def run_apidoc(_):
     )
 
 
+def run_git_to_sphinx():
+    """Add git content into doc"""
+
+    update_remote_branches_env_var = "GIT_TO_SPHINX_UPDATE_BRANCHES"
+    update_remote_branches = os.environ.get(update_remote_branches_env_var)
+    if os.environ.get("READTHEDOCS"):
+        os.environ[update_remote_branches_env_var] = "TRUE"
+
+    try:
+        current_dir = os.path.dirname(__file__)
+        subprocess.run(
+            [
+                os.path.join(current_dir, "git_to_sphinx.py"),
+                os.path.normpath(os.path.join(current_dir, "..")),
+                os.path.normpath(os.path.join(current_dir, "source")),
+            ]
+        )
+    finally:
+        if not update_remote_branches and os.environ.get(
+            update_remote_branches_env_var
+        ):
+            del os.environ[update_remote_branches_env_var]
+
+
 def setup(app):
     # Run apidoc
     app.connect("builder-inited", run_apidoc)
     # Add custom css/js for rtd template
     app.add_css_file("css/custom.css")
     app.add_js_file("js/custom.js")
-    # Add git content into doc
-    current_dir = os.path.dirname(__file__)
-    subprocess.run(
-        [
-            os.path.join(current_dir, "git_to_sphinx.py"),
-            os.path.normpath(os.path.join(current_dir, "..")),
-        ]
-    )
+    run_git_to_sphinx()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "apidoc_templates"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
@@ -93,15 +93,18 @@ html_use_old_search_snippets = True
 # -- Run apidoc when building the documentation-------------------------------
 
 napoleon_use_ivar = True
+add_module_names = False
 
 
 def run_apidoc(_):
     """Run apidoc on the marsha project and store source doc in ``source`` dir."""
+
     current_dir = os.path.dirname(__file__)
-    source_path = os.path.join(current_dir, "source")
-    output_path = os.path.normpath(os.path.join(current_dir, "..", "isshub"))
+
+    output_path = os.path.join(current_dir, "source")
+    source_path = os.path.normpath(os.path.join(current_dir, "..", "isshub"))
     exclude_paths = [
-        os.path.join(output_path, exclude_path) for exclude_path in ["*/tests/*"]
+        os.path.join(source_path, exclude_path) for exclude_path in ["*/tests/*"]
     ]
     apidoc.main(
         [
@@ -110,15 +113,13 @@ def run_apidoc(_):
             "--separate",
             "--doc-project",
             "Packages",
+            "--templatedir",
+            os.path.join(current_dir, "apidoc_templates"),
             "--output-dir",
-            source_path,
             output_path,
+            source_path,
         ]
         + exclude_paths
-    )
-    subprocess.run(
-        ["sed", "-i", "-e", r"s/ \(module\|package\)$//"]
-        + glob.glob(os.path.join(source_path, "*.rst"))
     )
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,7 @@ def run_apidoc(_):
     )
 
 
-def run_git_to_sphinx():
+def run_git_to_sphinx(_):
     """Add git content into doc"""
 
     update_remote_branches_env_var = "GIT_TO_SPHINX_UPDATE_BRANCHES"
@@ -150,7 +150,7 @@ def run_git_to_sphinx():
 def setup(app):
     # Run apidoc
     app.connect("builder-inited", run_apidoc)
+    app.connect("builder-inited", run_git_to_sphinx)
     # Add custom css/js for rtd template
     app.add_css_file("css/custom.css")
     app.add_js_file("js/custom.js")
-    run_git_to_sphinx()

--- a/docs/git_to_sphinx.py
+++ b/docs/git_to_sphinx.py
@@ -13,6 +13,7 @@ import rstcheck
 from cached_property import cached_property
 from git.objects.util import from_timestamp
 from pydriller import RepositoryMining as RepositoryMiningBase
+from pydriller.domain.commit import ModificationType
 from pydriller.git_repository import GitRepository as GitRepositoryBase
 
 
@@ -363,9 +364,9 @@ Last update
 {new_path}
 {old_path}
 
-------
-Source
-------
+-----------
+Last source
+-----------
 
 {source_code}
 
@@ -717,25 +718,44 @@ def render_commit_pages(commit, children, branches, tags):
     }
 
 
-def render_file_pages(path, commits_and_modifications, current_tree):
-    commits_and_modifications = [
-        (commit, modification)
-        for commit, modification in commits_and_modifications
-        if not commit.merge
-    ]
+def find_last_source_code(path, change, changes_by_file):
+    commit, modification, parent_change = change
+    if modification.source_code or modification.added or modification.removed:
+        return modification.source_code
+    if parent_change:
+        return find_last_source_code(path, parent_change, changes_by_file)
+    if (
+        modification.change_type == ModificationType.RENAME
+        and modification.old_path
+        and modification.old_path != modification.new_path
+    ):
+        return find_last_source_code(
+            modification.old_path,
+            changes_by_file[modification.old_path][0],
+            changes_by_file,
+        )
+    return None
+
+
+def render_file_pages(path, changes_by_file, current_tree):
+    last_change = changes_by_file[path][0]
+    changes = [change for change in changes_by_file[path] if not change[0].merge]
     modifications = "\n\n".join(
         "\n"
         + render_modification_for_commit_in_path(modification, commit, path).strip()
-        for commit, modification in commits_and_modifications
+        for commit, modification, *__ in changes
     )
-    last_commit, last_modification = commits_and_modifications[0]
-    first_commit, first_modification = commits_and_modifications[-1]
+    last_commit, last_modification = changes[0][:2]
+    first_commit, first_modification = changes[-1][:2]
     basename = os.path.basename(path)
     dirname = os.path.dirname(path)
     suffixed_dirname = dirname + "/"
     title = basename
     if not path_in_tree(path, current_tree):
         title += REMOVED
+    source_code = last_change[1].source_code or find_last_source_code(
+        path, last_change, changes_by_file
+    )
     return {
         f"content/{escape_path(path)}.rst": FILE_PAGE_TEMPLATE.format(
             path=path,
@@ -745,9 +765,9 @@ def render_file_pages(path, commits_and_modifications, current_tree):
             escaped_dirname=escape_path(suffixed_dirname),
             modifications=modifications,
             source_code=SOURCE_CODE_TEMPLATE.format(
-                source_code=indent(last_modification.source_code, "   ")
+                source_code=indent(source_code, "   ")
             )
-            if last_modification.source_code
+            if source_code
             else "(No source code)",
             last_type=MODIFICATION_TYPES[last_modification.change_type.name],
             last_updated_at=format_date(last_commit.committer_date),
@@ -1003,7 +1023,7 @@ def render(location, basepath=BASEPATH, clean=True):
     print("")
 
     print("Rendering commits...", end="")
-    commits_by_file = defaultdict(list)
+    changes_by_file = defaultdict(list)
     nb_commits = len(commits)
     for index, (__, commit) in enumerate(commits.items(), 1):
         print(f"\rRendering commits [{index}/{nb_commits}]", end="")
@@ -1021,9 +1041,19 @@ def render(location, basepath=BASEPATH, clean=True):
         )
         for modification in commit.modifications:
             if modification.new_path:
-                commits_by_file[modification.new_path].append((commit, modification))
+                changes_by_file[modification.new_path].append(
+                    [commit, modification, None]
+                )
             if modification.old_path and modification.old_path != modification.new_path:
-                commits_by_file[modification.old_path].append((commit, modification))
+                changes_by_file[modification.old_path].append(
+                    [commit, modification, None]
+                )
+
+    # link changes to their parent
+    for path, changes in changes_by_file.items():
+        for index, change in enumerate(changes[:-1]):
+            change[2] = changes[index + 1]
+
     print("")
 
     print("Building content tree...", end="")
@@ -1031,9 +1061,9 @@ def render(location, basepath=BASEPATH, clean=True):
     print("\rBuilding content tree [ok]")
 
     print("Rendering files...", end="")
-    nb_files = len(commits_by_file)
+    nb_files = len(changes_by_file)
     dirs = defaultdict(set)
-    for index, path in enumerate(sorted(commits_by_file), 1):
+    for index, path in enumerate(sorted(changes_by_file), 1):
         print(f"\rRendering files [{index}/{nb_files}]", end="")
 
         current, is_dir = path, False
@@ -1047,8 +1077,7 @@ def render(location, basepath=BASEPATH, clean=True):
                 break
 
         render_to_files(
-            render_file_pages(path, commits_by_file[path], current_tree),
-            basepath=basepath,
+            render_file_pages(path, changes_by_file, current_tree), basepath=basepath
         )
     print("")
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -6,4 +6,4 @@ IssHub internals
   :maxdepth: 2
 
    Git repository <git/index>
-   Python modules <source/modules>
+   Packages <source/modules>

--- a/isshub/domain/utils/entity.py
+++ b/isshub/domain/utils/entity.py
@@ -154,7 +154,7 @@ class BaseModelWithId(BaseModel):
     id: int = required_field(int)
 
     @field_validator(id)
-    def id_is_positive_integer(  # noqa  # pylint: disable=unused-argument
+    def validate_id_is_positive_integer(  # noqa  # pylint: disable=unused-argument
         self, field, value
     ):
         """Validate that the ``id`` field is a positive integer.


### PR DESCRIPTION
Abstract
========

Add some code examples and enhance the doc rendering, especially the "Packages" part (with added link between the source code in the "Git" part, and the "Packages" part)

Motivation
==========

Documentation can always be better, and going through the isshub doc, I found some pain points, now solved.

Rationale
=========

See individual commits
