### PR TITLE
build(python): Update minimal python version to 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   python_only_config: &python_only_config
     working_directory: ~/isshub
     docker:
-      - image: circleci/python:3.7.3
+      - image: circleci/python:3.8.5
 
   # build steps to save/restore the directory used by pip to cache downloaded packages
   save_pip_cache: &save_pip_cache

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ build:
   image: latest
 
 python:
-   version: 3.7
+   version: 3.8
    install:
       - method: pip
         path: .

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3 :: Only
 keywords =
@@ -19,7 +18,7 @@ keywords =
     github
     gitlab
 url = https://github.com/Isshub-io/isshub
-requires-python = >=3.7
+requires-python = >=3.8
 
 [options]
 zip_safe = True


### PR DESCRIPTION
Abstract
========

We change the python version to use in readthedocs and circle ci
configuration files, and in setup.cfg to make sure users will use the
correct version.

Motivation
==========

At the time this project was created, python 3.8 existed but was not
available on external tools like readthedocs and circleci.

They are now, so we can update the python version everywhere.

Rationale
=========

N/A