### PR TITLE
build(make): Remove the `dev-upgrade` make command (use `make dev`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,9 @@ install:  ## Install the project in the current environment, with its dependenci
 
 .PHONY: dev
 dev:  ## Install the project in the current environment, with its dependencies, including the ones needed in a development environment
-	@echo "$(BOLD)Installing $(PROJECT_NAME) $(PROJECT_VERSION) in dev mode$(RESET)"
-	@pip install -e .[dev,tests,lint,docs]
-	@$(MAKE) full-clean
-
-.PHONY: dev-upgrade
-dev-upgrade:  ## Upgrade all default+dev dependencies defined in setup.cfg
-	@pip install --upgrade pip
-	@pip install --upgrade `python -c 'import setuptools; o = setuptools.config.read_configuration("setup.cfg")["options"]; print(" ".join(o["install_requires"] + o["extras_require"]["dev"] + o["extras_require"]["tests"] + o["extras_require"]["lint"] + o["extras_require"]["docs"]))'`
-	@pip install -e .
+	@echo "$(BOLD)Installing (or upgrading) $(PROJECT_NAME) $(PROJECT_VERSION) in dev mode (with all dependencies)$(RESET)"
+	@pip install --upgrade pip setuptools
+	@pip install --upgrade -e .[dev,tests,lint,docs]
 	@$(MAKE) full-clean
 
 .PHONY: dist

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,11 @@ Tools
 
 All tools are incorporated in a `Makefile`, so it's easier to run commands. Tools listed below all have at least one `make` command to run them.
 
+.. note::
+
+   Run `make help` to list the available commands (the first one to run in a fresh python virtual environment being `make dev`)
+
+
 Linting
 =======
 


### PR DESCRIPTION
Abstract
========

Remove the `dev-upgrade` command from the `Makefile`, and update the
`dev` command to work for installing or upgrading.

Motivation
==========

The `dev-upgrade` command could be simplified from

`pip install --upgrade `python -c 'import setuptools...`

to exactly the same content as the `dev` one, except for the `--upgrade`
part.

Rationale
=========

The `dev-upgrade` command was removed and the `--upgrade` argument was
added in the `dev` command.
