### PR TITLE
fix(bdd): Rename "can/cannot be none" describing scenarios

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -376,9 +376,9 @@ And you'll be surprised to see this "BDD" thing used in very unusual case. An ex
         Given a Repository
         Then its name must be a string
 
-    Scenario: A Repository name cannot be None
+    Scenario: A Repository name is mandatory
         Given a Repository
-        Then its name cannot be None
+        Then its name is mandatory
 
 Yes, things like that :)
 

--- a/isshub/domain/contexts/code_repository/entities/namespace/features/describe.feature
+++ b/isshub/domain/contexts/code_repository/entities/namespace/features/describe.feature
@@ -8,9 +8,9 @@ Feature: Describing a Namespace
         Given a Namespace
         Then its id must be a positive integer
 
-    Scenario: A Namespace id cannot be None
+    Scenario: A Namespace id is mandatory
         Given a Namespace
-        Then its id cannot be None
+        Then its id is mandatory
 
     Scenario: A Namespace has a name
         Given a Namespace
@@ -20,9 +20,9 @@ Feature: Describing a Namespace
         Given a Namespace
         Then its name must be a string
 
-    Scenario: A Namespace name cannot be None
+    Scenario: A Namespace name is mandatory
         Given a Namespace
-        Then its name cannot be None
+        Then its name is mandatory
 
     Scenario: A Namespace has a description
         Given a Namespace
@@ -32,9 +32,9 @@ Feature: Describing a Namespace
         Given a Namespace
         Then its description must be a string
 
-    Scenario: A Namespace description can be None
+    Scenario: A Namespace description is optional
         Given a Namespace
-        Then its description can be None
+        Then its description is optional
 
     Scenario: A Namespace has a namespace
         Given a Namespace
@@ -44,9 +44,9 @@ Feature: Describing a Namespace
         Given a Namespace
         Then its namespace must be a Namespace
 
-    Scenario: A Namespace namespace can be None
+    Scenario: A Namespace namespace is optional
         Given a Namespace
-        Then its namespace can be None
+        Then its namespace is optional
 
     Scenario: A Namespace has a kind
         Given a Namespace
@@ -56,6 +56,6 @@ Feature: Describing a Namespace
         Given a Namespace
         Then its kind must be a NamespaceKind
 
-    Scenario: A Namespace kind cannot be None
+    Scenario: A Namespace kind is mandatory
         Given a Namespace
-        Then its kind cannot be None
+        Then its kind is mandatory

--- a/isshub/domain/contexts/code_repository/entities/namespace/tests/test_describe.py
+++ b/isshub/domain/contexts/code_repository/entities/namespace/tests/test_describe.py
@@ -78,11 +78,11 @@ def namespace_field_is_of_a_certain_type(
     check_field_value(namespace_factory, field_name, value, exception)
 
 
-@then(parsers.parse("its {field_name:w} cannot be none"))
-def namespace_field_cannot_be_none(namespace_factory, field_name):
+@then(parsers.parse("its {field_name:w} is mandatory"))
+def namespace_field_is_mandatory(namespace_factory, field_name):
     check_field_not_nullable(namespace_factory, field_name)
 
 
-@then(parsers.parse("its {field_name:w} can be none"))
-def namespace_field_can_be_none(namespace_factory, field_name):
+@then(parsers.parse("its {field_name:w} is optional"))
+def namespace_field_is_optional(namespace_factory, field_name):
     check_field_nullable(namespace_factory, field_name)

--- a/isshub/domain/contexts/code_repository/entities/repository/features/describe.feature
+++ b/isshub/domain/contexts/code_repository/entities/repository/features/describe.feature
@@ -8,9 +8,9 @@ Feature: Describing a Repository
         Given a Repository
         Then its id must be a positive integer
 
-    Scenario: A Repository id cannot be None
+    Scenario: A Repository id is mandatory
         Given a Repository
-        Then its id cannot be None
+        Then its id is mandatory
 
     Scenario: A Repository has a name
         Given a Repository
@@ -20,9 +20,9 @@ Feature: Describing a Repository
         Given a Repository
         Then its name must be a string
 
-    Scenario: A Repository name cannot be None
+    Scenario: A Repository name is mandatory
         Given a Repository
-        Then its name cannot be None
+        Then its name is mandatory
 
     Scenario: A Repository has a namespace
         Given a Repository
@@ -32,6 +32,6 @@ Feature: Describing a Repository
         Given a Repository
         Then its namespace must be a Namespace
 
-    Scenario: A Repository namespace cannot be None
+    Scenario: A Repository namespace is mandatory
         Given a Repository
-        Then its namespace cannot be None
+        Then its namespace is mandatory

--- a/isshub/domain/contexts/code_repository/entities/repository/tests/test_describe.py
+++ b/isshub/domain/contexts/code_repository/entities/repository/tests/test_describe.py
@@ -62,6 +62,6 @@ def repository_field_is_of_a_certain_type(
     check_field_value(repository_factory, field_name, value, exception)
 
 
-@then(parsers.parse("its {field_name:w} cannot be none"))
-def repository_field_cannot_be_none(repository_factory, field_name):
+@then(parsers.parse("its {field_name:w} is mandatory"))
+def repository_field_is_mandatory(repository_factory, field_name):
     check_field_not_nullable(repository_factory, field_name)


### PR DESCRIPTION
Abstract
========

All scenarios describing objects having names ending with
"can be None" or "cannot be None" are renamed respectively to
"is optional" and "is mandatory"

Motivation
==========

The language used to define the scenarios must not be tight to the code
and using the word "None" is too related to python. A way to change that
is to use the words "optional" and "mandatory"

Rationale
=========

N/A
