### PR TITLE
fix(entities): Add some validation on some fields

### DIFF
--- a/isshub/domain/contexts/code_repository/entities/namespace/__init__.py
+++ b/isshub/domain/contexts/code_repository/entities/namespace/__init__.py
@@ -1,10 +1,11 @@
 """Package defining the ``Namespace`` entity."""
 
 import enum
-from typing import Optional
+from typing import Any, Optional
 
 from isshub.domain.utils.entity import (
     BaseModelWithId,
+    field_validator,
     optional_field,
     required_field,
     validated,
@@ -69,3 +70,34 @@ class Namespace(_Namespace):
     """
 
     namespace: Optional[_Namespace] = optional_field(_Namespace)  # type: ignore
+
+    @field_validator(namespace)  # type: ignore
+    def validate_namespace_is_not_in_a_loop(  # noqa  # pylint: disable=unused-argument
+        self, field: Any, value: Any
+    ) -> None:
+        """Validate that the ``namespace`` field is not in a loop.
+
+        Being in a loop means that one of the descendants is the parent of one of the ascendants.
+
+        Parameters
+        ----------
+        field : Any
+            The field to validate. Passed via the ``@field_validator`` decorator.
+        value : Any
+            The value to validate for the `field`.
+
+        Raises
+        ------
+        ValueError
+            If the given namespace (`value`) is in a loop
+
+        """
+        if not value:
+            return
+
+        parent = value
+        while parent := parent.namespace:
+            if parent == value:
+                raise ValueError(
+                    f"{self.__class__.__name__}.namespace cannot be in a loop"
+                )

--- a/isshub/domain/contexts/code_repository/entities/namespace/features/describe.feature
+++ b/isshub/domain/contexts/code_repository/entities/namespace/features/describe.feature
@@ -12,6 +12,10 @@ Feature: Describing a Namespace
         Given a Namespace
         Then its id is mandatory
 
+    Scenario: A Namespace id cannot be changed
+        Given a Namespace
+        Then its id cannot be changed
+
     Scenario: A Namespace has a name
         Given a Namespace
         Then it must have a field named name

--- a/isshub/domain/contexts/code_repository/entities/namespace/features/describe.feature
+++ b/isshub/domain/contexts/code_repository/entities/namespace/features/describe.feature
@@ -59,3 +59,13 @@ Feature: Describing a Namespace
     Scenario: A Namespace kind is mandatory
         Given a Namespace
         Then its kind is mandatory
+
+    Scenario: A Namespace cannot be contained in itself
+        Given a Namespace
+        Then its namespace cannot be itself
+
+    Scenario: A Namespace namespace cannot be in a loop
+        Given a Namespace
+        And a second Namespace
+        And a third Namespace
+        Then we cannot create a relationships loop with these namespaces

--- a/isshub/domain/contexts/code_repository/entities/namespace/tests/test_describe.py
+++ b/isshub/domain/contexts/code_repository/entities/namespace/tests/test_describe.py
@@ -6,6 +6,7 @@ from pytest_bdd import given, parsers, scenario, scenarios, then
 
 from isshub.domain.contexts.code_repository.entities.namespace import NamespaceKind
 from isshub.domain.utils.testing.validation import (
+    FrozenAttributeError,
     check_field,
     check_field_not_nullable,
     check_field_nullable,
@@ -86,6 +87,17 @@ def namespace_field_is_mandatory(namespace_factory, field_name):
 @then(parsers.parse("its {field_name:w} is optional"))
 def namespace_field_is_optional(namespace_factory, field_name):
     check_field_nullable(namespace_factory, field_name)
+
+
+@scenario("../features/describe.feature", "A Namespace id cannot be changed")
+def test_namespace_id_cannot_be_changed():
+    pass
+
+
+@then("its id cannot be changed")
+def namespace_id_cannot_be_changed(namespace):
+    with pytest.raises(FrozenAttributeError):
+        namespace.id = namespace.id + 1
 
 
 @scenario("../features/describe.feature", "A Namespace cannot be contained in itself")

--- a/isshub/domain/contexts/code_repository/entities/namespace/tests/test_describe.py
+++ b/isshub/domain/contexts/code_repository/entities/namespace/tests/test_describe.py
@@ -86,3 +86,53 @@ def namespace_field_is_mandatory(namespace_factory, field_name):
 @then(parsers.parse("its {field_name:w} is optional"))
 def namespace_field_is_optional(namespace_factory, field_name):
     check_field_nullable(namespace_factory, field_name)
+
+
+@scenario("../features/describe.feature", "A Namespace cannot be contained in itself")
+def test_namespace_namespace_cannot_be_itself():
+    pass
+
+
+@then("its namespace cannot be itself")
+def namespace_namespace_cannot_be_itself(namespace):
+    namespace.namespace = namespace
+    with pytest.raises(ValueError):
+        namespace.validate()
+
+
+@scenario("../features/describe.feature", "A Namespace namespace cannot be in a loop")
+def test_namespace_namespace_cannot_be_in_a_loop():
+    pass
+
+
+@given("a second Namespace", target_fixture="namespace2")
+def a_second_namespace(namespace_factory):
+    return namespace_factory()
+
+
+@given("a third Namespace", target_fixture="namespace3")
+def a_third_namespace(namespace_factory):
+    return namespace_factory()
+
+
+@then("we cannot create a relationships loop with these namespaces")
+def namespace_relationships_cannot_create_a_loop(namespace, namespace2, namespace3):
+    namespace2.namespace = namespace3
+    namespace3.validate()
+    namespace2.validate()
+    namespace.validate()
+    namespace.namespace = namespace2
+    namespace3.validate()
+    namespace2.validate()
+    namespace.validate()
+    namespace3.namespace = namespace
+    with pytest.raises(ValueError):
+        namespace3.validate()
+    with pytest.raises(ValueError):
+        namespace2.validate()
+    with pytest.raises(ValueError):
+        namespace.validate()
+    namespace3.namespace = None
+    namespace3.validate()
+    namespace2.validate()
+    namespace.validate()

--- a/isshub/domain/contexts/code_repository/entities/repository/features/describe.feature
+++ b/isshub/domain/contexts/code_repository/entities/repository/features/describe.feature
@@ -12,6 +12,10 @@ Feature: Describing a Repository
         Given a Repository
         Then its id is mandatory
 
+    Scenario: A Repository id cannot be changed
+        Given a Repository
+        Then its id cannot be changed
+
     Scenario: A Repository has a name
         Given a Repository
         Then it must have a field named name

--- a/isshub/domain/contexts/code_repository/entities/repository/tests/test_describe.py
+++ b/isshub/domain/contexts/code_repository/entities/repository/tests/test_describe.py
@@ -5,6 +5,7 @@ from pytest import mark
 from pytest_bdd import given, parsers, scenario, scenarios, then
 
 from isshub.domain.utils.testing.validation import (
+    FrozenAttributeError,
     check_field,
     check_field_not_nullable,
     check_field_value,
@@ -65,3 +66,14 @@ def repository_field_is_of_a_certain_type(
 @then(parsers.parse("its {field_name:w} is mandatory"))
 def repository_field_is_mandatory(repository_factory, field_name):
     check_field_not_nullable(repository_factory, field_name)
+
+
+@scenario("../features/describe.feature", "A Repository id cannot be changed")
+def test_repository_id_cannot_be_changed():
+    pass
+
+
+@then("its id cannot be changed")
+def repository_id_cannot_be_changed(repository):
+    with pytest.raises(FrozenAttributeError):
+        repository.id = repository.id + 1

--- a/isshub/domain/utils/entity.py
+++ b/isshub/domain/utils/entity.py
@@ -41,13 +41,17 @@ def optional_field(field_type):
     )
 
 
-def required_field(field_type):
+def required_field(field_type, frozen=False):
     """Define a required field of the specified `field_type`.
 
     Parameters
     ----------
     field_type : type
-        The expected type of the field..
+        The expected type of the field.
+    frozen : bool
+        If set to ``False`` (the default), the field can be updated after being set at init time.
+        If set to ``True``, the field can be set at init time but cannot be changed later, else a
+        ``FrozenAttributeError`` exception will be raised.
 
     Returns
     -------
@@ -66,7 +70,11 @@ def required_field(field_type):
     >>> check_field_not_nullable(MyModel, 'my_field', my_field='foo')
 
     """
-    return attr.ib(validator=attr.validators.instance_of(field_type))
+    kwargs = {"validator": attr.validators.instance_of(field_type)}
+    if frozen:
+        kwargs["on_setattr"] = attr.setters.frozen
+
+    return attr.ib(**kwargs)
 
 
 def validated():
@@ -283,7 +291,7 @@ class BaseModelWithId(BaseModel):
 
     """
 
-    id: int = required_field(int)
+    id: int = required_field(int, frozen=True)
 
     @field_validator(id)
     def validate_id_is_positive_integer(  # noqa  # pylint: disable=unused-argument


### PR DESCRIPTION
Abstract
========

Deny namespaces relationships to make a loop, and forbid changing id on all entities once set at init time.

Motivation
==========

See details in commits.

Rationale
=========

N/A
